### PR TITLE
Un-link souvenir option until the page is created

### DIFF
--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -74,9 +74,7 @@ const Nav = function () {
               <Link href="/video-guide">
                 <a className="navbar-item">{t('video-guide')}</a>
               </Link>
-              <Link href="/souvenir">
-                <a className="navbar-item">{t('souvenir')}</a>
-              </Link>
+              <a className="navbar-item">{t('souvenir')}</a>
             </div>
           </div>
           <div className="navbar-item has-dropdown is-hoverable">


### PR DESCRIPTION
因为指向的路由不存在，所以点击会报错，可以暂时去掉链接。